### PR TITLE
Fix "View Threats in GTI" and "View Reports in GTI" links, fix skeleton loading

### DIFF
--- a/components/block.js
+++ b/components/block.js
@@ -215,10 +215,11 @@ polarity.export = PolarityComponent.extend({
     this.set('block._state.errorThreats', '');
     this.set('block._state.loadingThreats', true);
     this.sendIntegrationMessage(payload)
-      .then(({ threatResults }) => {
+      .then(({ threatResults, associationLink }) => {
         this.set('block.data.details.threats', threatResults.threats);
         this.set('block.data.details.threatsCount', threatResults.threatsCount);
-
+        this.set('block.data.details.associationLink', associationLink);
+        
         this.set('block._state.loadedThreats', true);
         this.get('block').notifyPropertyChange('data');
       })
@@ -237,9 +238,10 @@ polarity.export = PolarityComponent.extend({
     this.set('block._state.errorReports', '');
     this.set('block._state.loadingReports', true);
     this.sendIntegrationMessage(payload)
-      .then(({ reportResults }) => {
+      .then(({ reportResults, associationLink }) => {
         this.set('block.data.details.reports', reportResults.reports);
         this.set('block.data.details.reportsCount', reportResults.reportsCount);
+        this.set('block.data.details.associationLink', associationLink);
 
         this.set('block._state.loadedReports', true);
         this.get('block').notifyPropertyChange('data');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "google-threat-intelligence",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-threat-intelligence",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "main": "./integration.js",
   "private": true,
   "dependencies": {

--- a/templates/block.hbs
+++ b/templates/block.hbs
@@ -2371,8 +2371,8 @@
               }}
                 <div class="association-link">
                   <a
-                    class="full p-action skeleton-loader"
-                    style="display: flex;justify-content:flex-end;align-items-center;width: 55px;height: 16px;padding: 0px 4px 0px 4px;"
+                    class="narrow p-action skeleton-loader"
+                    style="display: flex; justify-content:flex-end; align-items: center; width: 55px; height: 16px; padding: 0px 4px 0px 4px;"
                   >
                     <svg
                       class="gti-icon"
@@ -2418,7 +2418,7 @@
                       if (eq associationTab "reporting") "reporting"
                     }}"
                   >
-                    View in
+                    View
                     {{#if (eq associationTab "threats")}}
                       Threats
                     {{else}}


### PR DESCRIPTION
With the reports and threats loading being moved to `onMessage`, the `associationLink` property also needed to be added in as part of `onMessage`.  Additionally, the method for coming up with the link needed to be fixed to take into account "type: custom" overlapping primary entity types due to the APT actor regex.

Finally, remove an invalid class on the skeleton loading and fixed it so it shows up on all screen widths.